### PR TITLE
Align progress API schemas with typed frontend contracts

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -55,9 +55,13 @@ def get_all_lessons(db: Session = Depends(get_db)):
     lessons = db.query(models.Lesson).order_by(models.Lesson.id).all()
     return lessons
 
-@app.post("/api/progress/{lesson_id}")
-def mark_lesson_understood(lesson_id: int, db: Session = Depends(get_db)):
-    user_id = 1  # Hard-coded Guest User
+@app.post("/api/progress/{lesson_id}", response_model=schemas.ProgressUpdateResponse)
+def mark_lesson_understood(
+    lesson_id: int,
+    progress_payload: schemas.ProgressUpdateRequest,
+    db: Session = Depends(get_db),
+):
+    user_id = progress_payload.user_id
     
     # Check if this user has studied this lesson before
     progress = db.query(models.UserProgress).filter(
@@ -89,7 +93,20 @@ def mark_lesson_understood(lesson_id: int, db: Session = Depends(get_db)):
         progress.next_review_date = date.today() + timedelta(days=progress.interval)
 
     db.commit()
-    return {"status": "success", "message": "Progress recorded and next review scheduled."}
+
+    updated_progress = db.query(models.UserProgress).filter(
+        models.UserProgress.user_id == user_id,
+        models.UserProgress.lesson_id == lesson_id
+    ).first()
+
+    return {
+        "status": "success",
+        "message": "Progress recorded and next review scheduled.",
+        "next_review_date": updated_progress.next_review_date,
+        "interval": updated_progress.interval,
+        "repetitions": updated_progress.repetitions,
+        "ease_factor": updated_progress.ease_factor,
+    }
 
 @app.get("/api/progress/due")
 def get_due_reviews(db: Session = Depends(get_db)):

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List, Optional
 from datetime import date
 
@@ -37,6 +37,19 @@ class LessonResponse(LessonBase):
 
     class Config:
         from_attributes = True
+
+
+class ProgressUpdateRequest(BaseModel):
+    user_id: int
+    quality: int = Field(ge=0, le=5)
+
+class ProgressUpdateResponse(BaseModel):
+    status: str
+    message: str
+    next_review_date: date
+    interval: int
+    repetitions: int
+    ease_factor: float
 
 # --- USER PROGRESS SCHEMAS ---
 class UserProgressBase(BaseModel):

--- a/frontend/app/discover/page.tsx
+++ b/frontend/app/discover/page.tsx
@@ -3,17 +3,7 @@ import { useEffect, useState } from "react";
 import VideoPlayer from "@/components/VideoPlayer";
 import QuizEngine from "@/components/QuizEngine";
 import MathRenderer from "@/components/MathRenderer";
-
-interface Lesson {
-  id: number;
-  title: string;
-  content_text: string;
-  content_math?: string;
-  video_url?: string;
-  quiz_question?: string;
-  quiz_options?: string[];
-  correct_answer?: string;
-}
+import type { Lesson } from "@/types/api";
 
 export default function DiscoverFeed() {
   const [lessons, setLessons] = useState<Lesson[]>([]);

--- a/frontend/app/lessons/[id]/page.tsx
+++ b/frontend/app/lessons/[id]/page.tsx
@@ -4,18 +4,7 @@ import { useParams } from "next/navigation";
 import VideoPlayer from "@/components/VideoPlayer";
 import QuizEngine from "@/components/QuizEngine";
 import MathRenderer from "@/components/MathRenderer";
-
-// Define the structure of our V2 Lesson data
-interface Lesson {
-  id: number;
-  title: string;
-  content_text: string;
-  content_math?: string;
-  video_url?: string;
-  quiz_question?: string;
-  quiz_options?: string[];
-  correct_answer?: string;
-}
+import type { Lesson, ProgressUpdateRequest, ProgressUpdateResponse } from "@/types/api";
 
 export default function LessonPage() {
   const params = useParams();
@@ -34,14 +23,17 @@ export default function LessonPage() {
 
   const handleMarkAsUnderstood = async () => {
     // This remains the same as T8, sending the signal to the SRS engine
+    const payload: ProgressUpdateRequest = { user_id: 1, quality: 5 };
+
     const response = await fetch(`http://127.0.0.1:8000/api/progress/${params.id}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ user_id: 1, quality: 5 }), 
+      body: JSON.stringify(payload),
     });
 
     if (response.ok) {
-      alert("Progress saved! The SRS engine has scheduled your next review.");
+      const data: ProgressUpdateResponse = await response.json();
+      alert(`${data.message} Next review: ${data.next_review_date}`);
     }
   };
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,25 @@
+export interface Lesson {
+  id: number;
+  module_id: number;
+  title: string;
+  content_text: string;
+  content_math?: string | null;
+  video_url?: string | null;
+  quiz_question?: string | null;
+  quiz_options?: string[] | null;
+  correct_answer?: string | null;
+}
+
+export interface ProgressUpdateRequest {
+  user_id: number;
+  quality: 0 | 1 | 2 | 3 | 4 | 5;
+}
+
+export interface ProgressUpdateResponse {
+  status: "success";
+  message: string;
+  next_review_date: string;
+  interval: number;
+  repetitions: number;
+  ease_factor: number;
+}


### PR DESCRIPTION
### Motivation

- Ensure frontend and backend share an explicit, versioned contract for the SRS/progress flow to reduce duplication and runtime type mismatch. 
- Surface SRS scheduling metadata (`next_review_date`, `interval`, `repetitions`, `ease_factor`) to the client so the UI can provide immediate, accurate feedback and enable future XP/gamification. 
- Add simple validation for progress payloads to prevent invalid quality scores from reaching the SRS logic.

### Description

- Added `ProgressUpdateRequest` and `ProgressUpdateResponse` Pydantic models in `backend/schemas.py` and bounded `quality` with `Field(ge=0, le=5)`.
- Updated `POST /api/progress/{lesson_id}` in `backend/main.py` to accept a typed `progress_payload`, use its `user_id`, and return structured scheduling metadata in the response body.
- Introduced shared TypeScript API types in `frontend/src/types/api.ts` for `Lesson`, `ProgressUpdateRequest`, and `ProgressUpdateResponse` to centralize contracts.
- Wired the frontend pages to use the shared types: `frontend/app/discover/page.tsx` imports `Lesson`, and `frontend/app/lessons/[id]/page.tsx` sends a typed `ProgressUpdateRequest` and parses `ProgressUpdateResponse` to show next-review info while preserving the mastery-gate flow.

### Testing

- Ran `cd frontend && npm run lint` and the lint pass completed successfully.
- Ran `python -m py_compile backend/main.py backend/schemas.py` and the Python files compiled without syntax errors.
- Performed local manual verification of the updated progress POST flow in the lesson page (typed request body and parsed typed response) and observed expected alert feedback from the returned `next_review_date`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b510b288e4832bbb1a39ff987bdb8f)