### PR TITLE
Flow state engine: viewport autoplay and auto-swipe for Discover feed

### DIFF
--- a/frontend/app/discover/page.tsx
+++ b/frontend/app/discover/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import VideoPlayer from "@/components/VideoPlayer";
 import QuizEngine from "@/components/QuizEngine";
 import MathRenderer from "@/components/MathRenderer";
@@ -8,6 +8,7 @@ import type { Lesson } from "@/types/api";
 export default function DiscoverFeed() {
   const [lessons, setLessons] = useState<Lesson[]>([]);
   const [loading, setLoading] = useState(true);
+  const sectionRefs = useRef<Array<HTMLElement | null>>([]);
 
   useEffect(() => {
     fetch("http://127.0.0.1:8000/api/lessons")
@@ -19,39 +20,50 @@ export default function DiscoverFeed() {
       .catch((err) => console.error("Discover Feed Error:", err));
   }, []);
 
-  if (loading) return (
-    <div className="h-screen flex items-center justify-center bg-black text-white font-mono uppercase tracking-[0.2rem]">
-      Initializing Engineering Stream...
-    </div>
-  );
+  const handleLessonSuccess = (lessonIndex: number) => {
+    const nextSection = sectionRefs.current[lessonIndex + 1];
+
+    if (!nextSection) return;
+
+    nextSection.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+      inline: "nearest",
+    });
+  };
+
+  if (loading)
+    return (
+      <div className="h-screen flex items-center justify-center bg-black text-white font-mono uppercase tracking-[0.2rem]">
+        Initializing Engineering Stream...
+      </div>
+    );
 
   return (
     /* Snap-Scroll Physics:
-       'snap-y snap-mandatory' creates the 'TikTok' feel where the 
+       'snap-y snap-mandatory' creates the 'TikTok' feel where the
        browser 'locks' onto each child section during a scroll.
     */
     <main className="h-screen overflow-y-scroll snap-y snap-mandatory bg-black scrollbar-hide">
-      {lessons.map((lesson) => (
-        <section 
-          key={lesson.id} 
+      {lessons.map((lesson, index) => (
+        <section
+          key={lesson.id}
+          ref={(element) => {
+            sectionRefs.current[index] = element;
+          }}
           className="h-screen w-full snap-start flex flex-col items-center justify-center p-4"
         >
           {/* The Content Card */}
           <div className="max-w-md w-full bg-white rounded-[2.5rem] overflow-hidden shadow-2xl flex flex-col h-[85vh] border-4 border-gray-900">
-            
             {/* Header: Lesson ID and Branding */}
             <div className="px-6 py-4 bg-blue-900 text-white flex justify-between items-center border-b border-blue-800">
               <span className="text-[10px] font-black tracking-widest uppercase italic">Project Delta</span>
-              <span className="text-[10px] bg-blue-700 px-2 py-0.5 rounded-full font-bold">
-                {lesson.id} / 12
-              </span>
+              <span className="text-[10px] bg-blue-700 px-2 py-0.5 rounded-full font-bold">{lesson.id} / 12</span>
             </div>
 
             {/* Scrollable Content Body */}
             <div className="flex-1 overflow-y-auto p-6 space-y-6">
-              <h2 className="text-2xl font-black text-gray-900 leading-tight">
-                {lesson.title}
-              </h2>
+              <h2 className="text-2xl font-black text-gray-900 leading-tight">{lesson.title}</h2>
 
               {lesson.video_url && <VideoPlayer url={lesson.video_url} />}
 
@@ -59,9 +71,7 @@ export default function DiscoverFeed() {
                 <p className="leading-relaxed">{lesson.content_text}</p>
               </div>
 
-              {lesson.content_math && (
-                <MathRenderer formula={lesson.content_math} />
-              )}
+              {lesson.content_math && <MathRenderer formula={lesson.content_math} />}
 
               {lesson.quiz_question && (
                 <div className="pt-4 border-t border-gray-100">
@@ -69,7 +79,10 @@ export default function DiscoverFeed() {
                     question={lesson.quiz_question}
                     options={lesson.quiz_options || []}
                     correctAnswer={lesson.correct_answer || ""}
-                    onSuccess={() => console.log(`Mastered Lesson ${lesson.id}`)}
+                    onSuccess={() => {
+                      console.log(`Mastered Lesson ${lesson.id}`);
+                      handleLessonSuccess(index);
+                    }}
                   />
                 </div>
               )}

--- a/frontend/src/components/QuizEngine.tsx
+++ b/frontend/src/components/QuizEngine.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 interface QuizEngineProps {
   question: string;
@@ -13,16 +13,31 @@ export default function QuizEngine({ question, options, correctAnswer, onSuccess
   const [selected, setSelected] = useState<string | null>(null);
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+  const successTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (successTimeoutRef.current) {
+        clearTimeout(successTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const handleSubmit = () => {
     if (!selected) return;
-    
+
     setHasSubmitted(true);
     const correct = selected === correctAnswer;
     setIsCorrect(correct);
 
     if (correct) {
-      onSuccess(); // Fire the flare to the parent page!
+      if (successTimeoutRef.current) {
+        clearTimeout(successTimeoutRef.current);
+      }
+
+      successTimeoutRef.current = setTimeout(() => {
+        onSuccess(); // Fire the flare to the parent page after a short success pause.
+      }, 1500);
     }
   };
 
@@ -30,16 +45,16 @@ export default function QuizEngine({ question, options, correctAnswer, onSuccess
     <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200 mb-8">
       <h3 className="text-xl font-bold text-gray-800 mb-4">Knowledge Check</h3>
       <p className="text-gray-700 font-medium mb-4">{question}</p>
-      
+
       <div className="space-y-3 mb-6">
         {options.map((option, index) => {
           // Dynamic styling based on state
           let buttonStyle = "border-gray-300 text-gray-700 hover:bg-blue-50";
-          
+
           if (selected === option) {
             buttonStyle = "border-blue-600 bg-blue-50 text-blue-800 ring-1 ring-blue-600";
           }
-          
+
           if (hasSubmitted && option === correctAnswer) {
             buttonStyle = "border-green-500 bg-green-50 text-green-800 ring-1 ring-green-500";
           } else if (hasSubmitted && selected === option && !isCorrect) {
@@ -51,7 +66,7 @@ export default function QuizEngine({ question, options, correctAnswer, onSuccess
               key={index}
               onClick={() => {
                 // Prevent changing answer after submitting correctly
-                if (isCorrect) return; 
+                if (isCorrect) return;
                 setSelected(option);
                 setHasSubmitted(false); // Reset if they try again
               }}
@@ -69,8 +84,8 @@ export default function QuizEngine({ question, options, correctAnswer, onSuccess
           onClick={handleSubmit}
           disabled={!selected}
           className={`w-full py-3 rounded-md font-bold transition-all duration-200 ${
-            selected 
-              ? "bg-blue-600 text-white hover:bg-blue-700 shadow-md" 
+            selected
+              ? "bg-blue-600 text-white hover:bg-blue-700 shadow-md"
               : "bg-gray-200 text-gray-400 cursor-not-allowed"
           }`}
         >

--- a/frontend/src/components/VideoPlayer.tsx
+++ b/frontend/src/components/VideoPlayer.tsx
@@ -1,15 +1,73 @@
-import React from "react";
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
 
 interface VideoPlayerProps {
   url: string;
 }
 
+const PLAYER_COMMAND_TARGET = "https://www.youtube.com";
+
+function withYouTubePlayerParams(rawUrl: string): string {
+  try {
+    const parsedUrl = new URL(rawUrl);
+    parsedUrl.searchParams.set("enablejsapi", "1");
+    parsedUrl.searchParams.set("playsinline", "1");
+    parsedUrl.searchParams.set("rel", "0");
+    parsedUrl.searchParams.set("mute", "1");
+    return parsedUrl.toString();
+  } catch {
+    return rawUrl;
+  }
+}
+
 export default function VideoPlayer({ url }: VideoPlayerProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [isFullyVisible, setIsFullyVisible] = useState(false);
+
+  const playerUrl = useMemo(() => withYouTubePlayerParams(url), [url]);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsFullyVisible(entry.isIntersecting && entry.intersectionRatio >= 1);
+      },
+      {
+        threshold: [1],
+      }
+    );
+
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe?.contentWindow) return;
+
+    iframe.contentWindow.postMessage(
+      JSON.stringify({
+        event: "command",
+        func: isFullyVisible ? "playVideo" : "pauseVideo",
+        args: [],
+      }),
+      PLAYER_COMMAND_TARGET
+    );
+  }, [isFullyVisible]);
+
   return (
-    <div className="w-full aspect-video bg-black rounded-lg overflow-hidden shadow-md mb-8">
+    <div ref={containerRef} className="w-full aspect-video bg-black rounded-lg overflow-hidden shadow-md mb-8">
       <iframe
+        ref={iframeRef}
         className="w-full h-full"
-        src={url}
+        src={playerUrl}
         title="Engineering Micro-Lesson"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
         allowFullScreen


### PR DESCRIPTION
### Motivation
- Improve the Discover feed to feel native-mobile by auto-playing videos only when fully visible and automatically advancing the feed after a correct quiz answer.
- Prevent intrusive iframe reloads while still enabling play/pause control for YouTube embeds.
- Give learners a short pause to read the success message before advancing to the next lesson.

### Description
- Implemented viewport-aware playback in `frontend/src/components/VideoPlayer.tsx` using `IntersectionObserver` with `threshold: [1]` so a video is considered visible only when fully in the viewport and its `intersectionRatio >= 1`.
- Enabled YouTube iframe control by appending (`enablejsapi=1`, `playsinline=1`, `rel=0`, `mute=1`) to the video URL and sending `postMessage` commands (`playVideo` / `pauseVideo`) to the YouTube origin to avoid full iframe reloads.
- Updated `frontend/src/components/QuizEngine.tsx` to delay calling `onSuccess` by `1500ms` after a correct answer and added timeout cleanup on unmount to avoid leaks or races.
- Wired automatic swipe in `frontend/app/discover/page.tsx` by storing section DOM nodes in a `useRef` array (`sectionRefs`) where `sectionRefs.current[index]` matches the lesson at `lessons[index]`, and programmatically calling `sectionRefs.current[index + 1]?.scrollIntoView({ behavior: 'smooth' })` when a quiz succeeds; `snap-y snap-mandatory` is preserved so native snap physics settle after the smooth programmatic scroll.

### Testing
- Ran `npm run lint` in `frontend/` and it completed successfully.
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` and performed a manual browser verification of `/discover` in a mobile viewport, producing a screenshot artifact.
- Verified the following behaviors during manual testing: videos play only when fully visible and pause when off-screen; correct-quiz shows success message followed by a smooth scroll to the next lesson after ~1.5s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73094d4c4832bba38ae62a77c9e0b)