### PR TITLE
Implement Ticket #15: Active Recall review loop on /review

### DIFF
--- a/frontend/app/review/page.tsx
+++ b/frontend/app/review/page.tsx
@@ -1,33 +1,130 @@
 "use client";
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import QuizEngine from "@/components/QuizEngine";
+import type { Lesson, ProgressUpdateRequest, ReviewQueueResponse } from "@/types/api";
 
 export default function ReviewQueuePage() {
-  const router = useRouter();
+  const [lesson, setLesson] = useState<Lesson | null>(null);
+  const [activeLessonId, setActiveLessonId] = useState<number | null>(null);
+  const [isQueueComplete, setIsQueueComplete] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const loadNextLesson = useCallback(async () => {
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const queueResponse = await fetch("http://127.0.0.1:8000/api/progress/review-queue");
+      if (!queueResponse.ok) {
+        throw new Error("Unable to fetch review queue.");
+      }
+
+      const queueData: ReviewQueueResponse = await queueResponse.json();
+
+      if (queueData.lesson_id === null) {
+        setLesson(null);
+        setActiveLessonId(null);
+        setIsQueueComplete(true);
+        return;
+      }
+
+      const lessonResponse = await fetch(`http://127.0.0.1:8000/api/lessons/${queueData.lesson_id}`);
+      if (!lessonResponse.ok) {
+        throw new Error("Unable to fetch the next lesson for review.");
+      }
+
+      const lessonData: Lesson = await lessonResponse.json();
+      setLesson(lessonData);
+      setActiveLessonId(queueData.lesson_id);
+      setIsQueueComplete(false);
+    } catch (error) {
+      console.error("Failed to load review queue:", error);
+      setErrorMessage("We couldn't load your review queue. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    fetch("http://127.0.0.1:8000/api/progress/review-queue")
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.lesson_id) {
-          // If a lesson is due, instantly send the user to that lesson page!
-          router.push(`/lessons/${data.lesson_id}`);
-        } else {
-          // If nothing is due, send them back to the dashboard
-          router.push("/");
-        }
-      })
-      .catch((err) => {
-        console.error("Failed to fetch review queue:", err);
-        router.push("/");
+    loadNextLesson();
+  }, [loadNextLesson]);
+
+  const handleQuizSuccess = async (isFirstTry: boolean) => {
+    if (!activeLessonId) return;
+
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    const payload: ProgressUpdateRequest = {
+      user_id: 1,
+      quality: isFirstTry ? 5 : 1,
+    };
+
+    try {
+      const response = await fetch(`http://127.0.0.1:8000/api/progress/${activeLessonId}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
       });
-  }, [router]);
+
+      if (!response.ok) {
+        throw new Error("Unable to submit review result.");
+      }
+
+      await loadNextLesson();
+    } catch (error) {
+      console.error("Failed to submit review result:", error);
+      setErrorMessage("Your answer was correct, but we couldn't save your progress. Please try again.");
+      setIsLoading(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-[50vh] flex items-center justify-center px-6">
+        <div className="text-center">
+          <h2 className="text-2xl font-bold text-blue-900 animate-pulse">Loading your active recall session...</h2>
+          <p className="text-gray-600 mt-3">Preparing the next review prompt.</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-[50vh]">
-      <h2 className="text-2xl font-bold text-blue-900 animate-pulse">
-        Finding your next review...
-      </h2>
+    <div className="max-w-3xl mx-auto p-6">
+      <h1 className="text-3xl font-bold text-blue-900 mb-2">Daily Review</h1>
+      <p className="text-gray-600 mb-8">Strengthen memory by recalling the answer before you reveal mastery.</p>
+
+      {errorMessage && (
+        <div className="mb-6 p-4 rounded-md border border-red-200 bg-red-50 text-red-700">{errorMessage}</div>
+      )}
+
+      {isQueueComplete ? (
+        <div className="bg-white border border-green-200 rounded-xl p-8 shadow-sm text-center">
+          <h2 className="text-2xl font-bold text-green-700 mb-3">🎉 Review Complete</h2>
+          <p className="text-gray-700 mb-6">No lessons are due right now. Great consistency—keep the streak alive.</p>
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center px-6 py-3 rounded-full font-bold bg-blue-600 text-white hover:bg-blue-700 transition-all duration-200"
+          >
+            Back to Dashboard
+          </Link>
+        </div>
+      ) : (
+        lesson?.quiz_question &&
+        lesson.quiz_options &&
+        lesson.correct_answer && (
+          <QuizEngine
+            question={lesson.quiz_question}
+            options={lesson.quiz_options}
+            correctAnswer={lesson.correct_answer}
+            onSuccess={handleQuizSuccess}
+          />
+        )
+      )}
     </div>
   );
 }

--- a/frontend/src/components/QuizEngine.tsx
+++ b/frontend/src/components/QuizEngine.tsx
@@ -5,14 +5,14 @@ interface QuizEngineProps {
   question: string;
   options: string[];
   correctAnswer: string;
-  onSuccess: () => void; // The flare gun to alert the Motherboard
+  onSuccess: (isFirstTry: boolean) => void;
 }
 
 export default function QuizEngine({ question, options, correctAnswer, onSuccess }: QuizEngineProps) {
-  // Local state to track what the user is doing
   const [selected, setSelected] = useState<string | null>(null);
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+  const [hadIncorrectAttempt, setHadIncorrectAttempt] = useState(false);
   const successTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -35,10 +35,14 @@ export default function QuizEngine({ question, options, correctAnswer, onSuccess
         clearTimeout(successTimeoutRef.current);
       }
 
+      const isFirstTry = !hadIncorrectAttempt;
       successTimeoutRef.current = setTimeout(() => {
-        onSuccess(); // Fire the flare to the parent page after a short success pause.
+        onSuccess(isFirstTry);
       }, 1500);
+      return;
     }
+
+    setHadIncorrectAttempt(true);
   };
 
   return (
@@ -48,7 +52,6 @@ export default function QuizEngine({ question, options, correctAnswer, onSuccess
 
       <div className="space-y-3 mb-6">
         {options.map((option, index) => {
-          // Dynamic styling based on state
           let buttonStyle = "border-gray-300 text-gray-700 hover:bg-blue-50";
 
           if (selected === option) {
@@ -65,10 +68,9 @@ export default function QuizEngine({ question, options, correctAnswer, onSuccess
             <button
               key={index}
               onClick={() => {
-                // Prevent changing answer after submitting correctly
                 if (isCorrect) return;
                 setSelected(option);
-                setHasSubmitted(false); // Reset if they try again
+                setHasSubmitted(false);
               }}
               className={`w-full text-left p-3 rounded-md border transition-all duration-200 ${buttonStyle}`}
             >

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -24,6 +24,10 @@ export interface ProgressUpdateResponse {
   ease_factor: number;
 }
 
+export interface ReviewQueueResponse {
+  lesson_id: number | null;
+}
+
 export interface ModuleProgressSummary {
   module_id: number;
   module_title: string;


### PR DESCRIPTION
### Motivation
- Replace the previous redirect-only `/review` behavior with an in-app daily Spaced Repetition (SRS) loop so users can complete active recall sessions without leaving the app. 
- Only the quiz should be shown during reviews and the SRS engine must receive a quality signal depending on whether the user answered correctly on the first try. 
- The flow must re-trigger the queue after submitting progress and present clear loading/error states to avoid UI flicker.

### Description
- Reworked `app/review/page.tsx` to fetch `GET /api/progress/review-queue`, load `GET /api/lessons/{id}` when `lesson_id` exists, render only `QuizEngine` for the review, show a completion view when `lesson_id` is `null`, and loop by reloading the queue after each submission. 
- Updated `src/components/QuizEngine.tsx` so `onSuccess` receives an `isFirstTry: boolean` parameter and added local tracking for prior incorrect attempts to determine the quality value. 
- Added `ReviewQueueResponse` to `src/types/api.ts` and used the centralized types `Lesson` and `ProgressUpdateRequest` for payload/response shapes. 
- Implemented clean Tailwind-based loading and error states and POSTed progress to `POST /api/progress/{lesson_id}` with `quality: 5` for first-try correct and `quality: 1` otherwise.

### Testing
- Ran `npm run lint` in the frontend and it completed successfully. 
- Attempted `npm run build` and the build failed due to Next.js being unable to download the Inter font from Google Fonts in this environment, which is unrelated to the ticket logic. 
- Started the dev server and executed an automated Playwright script to load `/review` and capture a screenshot, which completed successfully and produced an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b734846670832badb98354285f99f1)