### PR TITLE
Standardize client-side admin role checks and harden public.users RLS policy

### DIFF
--- a/backend/sql/2026-03-26_users_rls_hardening.sql
+++ b/backend/sql/2026-03-26_users_rls_hardening.sql
@@ -1,0 +1,20 @@
+-- RLS hardening for public.users.
+-- This migration removes any recursive/self-referencing users-table policies
+-- and enforces a single self-read policy with explicit UUID->text casting.
+
+ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can read own profile" ON public.users;
+DROP POLICY IF EXISTS "Users can view own user data" ON public.users;
+DROP POLICY IF EXISTS "Allow authenticated users to read own row" ON public.users;
+DROP POLICY IF EXISTS "Admins can read all users" ON public.users;
+DROP POLICY IF EXISTS "admin_read_all_users" ON public.users;
+DROP POLICY IF EXISTS "Admin users can read all users" ON public.users;
+DROP POLICY IF EXISTS "Users select policy" ON public.users;
+DROP POLICY IF EXISTS "Users are viewable by everyone" ON public.users;
+
+CREATE POLICY "users_self_read"
+ON public.users
+FOR SELECT
+TO authenticated
+USING (auth.uid()::text = id);

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -2,8 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
-import { createClient } from "@/lib/supabase";
+import { useAdminRole } from "@/hooks/useAdminRole";
 import {
   Home,
   Compass,
@@ -15,50 +14,7 @@ import {
 
 export default function BottomNav() {
   const pathname = usePathname();
-  const supabase = useMemo(() => createClient(), []);
-  const [isAdmin, setIsAdmin] = useState(false);
-  const [roleLoading, setRoleLoading] = useState(true);
-
-  useEffect(() => {
-    const checkRole = async () => {
-      setRoleLoading(true);
-
-      const {
-        data: { user },
-        error: userError,
-      } = await supabase.auth.getUser();
-
-      console.log("BottomNav auth user:", user);
-      console.log("BottomNav auth user error:", userError);
-
-      if (!user) {
-        setIsAdmin(false);
-        setRoleLoading(false);
-        return;
-      }
-
-      const { data, error } = await supabase
-        .from("users")
-        .select("role")
-        .eq("id", user.id)
-        .maybeSingle();
-
-
-      const admin = data?.role?.toLowerCase() === "admin";
-      setIsAdmin(admin);
-      setRoleLoading(false);
-    };
-
-    checkRole();
-
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange(() => {
-      checkRole();
-    });
-
-    return () => subscription.unsubscribe();
-  }, [supabase]);
+  const { isAdmin, roleLoading } = useAdminRole();
 
   const baseNavItems = [
     { name: "Home", href: "/", icon: Home },

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -2,59 +2,16 @@
 
 import { usePathname, useRouter } from "next/navigation";
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { createClient } from "@/lib/supabase";
+import { useAdminRole } from "@/hooks/useAdminRole";
 import Image from "next/image";
 
 export default function Navbar() {
   const pathname = usePathname();
   const router = useRouter();
-  const [isAdmin, setIsAdmin] = useState(false);
-  const [roleLoading, setRoleLoading] = useState(true);
-
   const supabase = useMemo(() => createClient(), []);
-
-  useEffect(() => {
-    const checkRole = async () => {
-      setRoleLoading(true);
-
-      const {
-        data: { user },
-        error: userError,
-      } = await supabase.auth.getUser();
-
-      if (!user) {
-        setIsAdmin(false);
-        setRoleLoading(false);
-        return;
-      }
-
-      const { data, error } = await supabase
-        .from("users")
-        .select("role")
-        .eq("id", user.id)
-        .maybeSingle();
-
-      console.log("role query data:", data);
-      console.log("role query error:", error);
-
-      const admin = data?.role?.toLowerCase() === "admin";
-      setIsAdmin(admin);
-      setRoleLoading(false);
-
-      console.log("isAdmin state should become:", admin);
-    };
-
-    checkRole();
-
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange(() => {
-      checkRole();
-    });
-
-    return () => subscription.unsubscribe();
-  }, [supabase]);
+  const { isAdmin } = useAdminRole();
 
   if (pathname === "/login" || pathname === "/signup") {
     return null;

--- a/frontend/src/hooks/useAdminRole.ts
+++ b/frontend/src/hooks/useAdminRole.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { createClient } from "@/lib/supabase";
+
+export function useAdminRole() {
+  const supabase = useMemo(() => createClient(), []);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [roleLoading, setRoleLoading] = useState(true);
+
+  useEffect(() => {
+    const resolveRole = async () => {
+      setRoleLoading(true);
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        setIsAdmin(false);
+        setRoleLoading(false);
+        return;
+      }
+
+      const { data } = await supabase
+        .from("users")
+        .select("role")
+        .eq("id", user.id)
+        .maybeSingle();
+
+      setIsAdmin(data?.role?.toLowerCase() === "admin");
+      setRoleLoading(false);
+    };
+
+    void resolveRole();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(() => {
+      void resolveRole();
+    });
+
+    return () => subscription.unsubscribe();
+  }, [supabase]);
+
+  return { isAdmin, roleLoading };
+}


### PR DESCRIPTION
### Motivation
- Enforce a safe RLS model that prevents recursive/self-referencing policies on `public.users` and ensure client-side role checks remain presentation-only.
- Consolidate duplicated role-detection logic into a single, audited pattern using `supabase.auth.getUser()`, `.maybeSingle()`, and `onAuthStateChange()` to avoid crashes and inconsistent UI state.

### Description
- Added a reusable hook `frontend/src/hooks/useAdminRole.ts` that resolves admin status using `await supabase.auth.getUser()`, queries `public.users` with `.maybeSingle()`, normalizes the role via `data?.role?.toLowerCase() === "admin"`, and subscribes to `supabase.auth.onAuthStateChange()` for dynamic updates.
- Refactored `frontend/src/components/Navbar.tsx` and `frontend/src/components/BottomNav.tsx` to consume the new `useAdminRole` hook and removed duplicated role-checking side-effects while preserving all Tailwind classes and navigation behavior.
- Added a SQL hardening migration `backend/sql/2026-03-26_users_rls_hardening.sql` that enables RLS on `public.users`, drops common broad/recursive policies if present, and creates a single self-read policy using explicit casting: `auth.uid()::text = id`.
- Standardized the frontend pattern for UI-only role checks: stable Supabase client, `supabase.auth.getUser()`, `.maybeSingle()` when reading `public.users`, safe lowercase comparison for `admin`, and optional `onAuthStateChange()` subscription.

### Testing
- Ran frontend lint with `npm --prefix frontend run lint`; the command completed and reported existing pre-existing issues (2 errors and multiple warnings across unrelated files), so the lint step failed overall but did not introduce new lint errors in the modified files.
- Verified that the refactored components compile locally in the codebase (no TypeScript errors introduced by the hook consumption).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c57ad770ec832bb9c09819179aa96c)