### PR TITLE
Harden auth boundaries and improve discover/media resilience

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,38 +1,45 @@
-from pydantic import BaseModel, Field, ConfigDict, field_validator
-from typing import List, Optional, Any
 from datetime import date
 import json
+from typing import Dict, List, Optional, Union
 
-# --- USER SCHEMAS ---
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+QuizOptionsInput = Union[List[str], Dict[str, str], str]
+
+
 class UserBase(BaseModel):
     email: str
     role: str
     first_name: Optional[str] = None
     last_name: Optional[str] = None
 
+
 class User(UserBase):
     id: str
 
     model_config = ConfigDict(from_attributes=True)
 
-# --- MODULE SCHEMAS ---
+
 class ModuleBase(BaseModel):
     title: str
     description: str
 
+
 class ModuleCreate(ModuleBase):
     pass
+
 
 class ModuleResponse(ModuleBase):
     id: int
 
     model_config = ConfigDict(from_attributes=True)
 
+
 class ModuleUpdate(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
 
-# --- LESSON SCHEMAS ---
+
 class LessonBase(BaseModel):
     module_id: int
     title: str
@@ -40,11 +47,13 @@ class LessonBase(BaseModel):
     content_math: Optional[str] = None
     video_url: Optional[str] = None
     quiz_question: Optional[str] = None
-    quiz_options: Optional[Any] = None # Accept any format temporarily for flexible creation
+    quiz_options: Optional[QuizOptionsInput] = None
     correct_answer: Optional[str] = None
+
 
 class LessonCreate(LessonBase):
     pass
+
 
 class LessonUpdate(BaseModel):
     title: Optional[str] = None
@@ -52,8 +61,9 @@ class LessonUpdate(BaseModel):
     content_math: Optional[str] = None
     video_url: Optional[str] = None
     quiz_question: Optional[str] = None
-    quiz_options: Optional[Any] = None 
+    quiz_options: Optional[QuizOptionsInput] = None
     correct_answer: Optional[str] = None
+
 
 class LessonResponse(BaseModel):
     id: int
@@ -61,43 +71,49 @@ class LessonResponse(BaseModel):
     title: str
     content_text: str
     content_math: Optional[str] = None
-    video_url: Optional[str] = None 
+    video_url: Optional[str] = None
     quiz_question: Optional[str] = None
     quiz_options: Optional[List[str]] = None
     correct_answer: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 
-    # 🛠️ CRITICAL FIX: Convert DB string to List[str] automatically
-    @field_validator('quiz_options', mode='before')
+    @field_validator("quiz_options", mode="before")
     @classmethod
-    def parse_quiz_options(cls, v):
-        if isinstance(v, str):
-            # Try to parse it as JSON first
+    def parse_quiz_options(cls, value: Optional[QuizOptionsInput]) -> Optional[List[str]]:
+        """
+        Normalize heterogeneous quiz-option storage into a predictable list for frontend consumers.
+        This keeps legacy rows compatible while the system converges on JSON list storage.
+        """
+        if value is None:
+            return None
+
+        if isinstance(value, list):
+            return [str(item) for item in value]
+
+        if isinstance(value, dict):
+            return [str(item) for item in value.values()]
+
+        if isinstance(value, str):
             try:
-                parsed = json.loads(v)
+                parsed = json.loads(value)
                 if isinstance(parsed, list):
-                    return parsed
+                    return [str(item) for item in parsed]
             except Exception:
                 pass
-            
-            # If it's a raw Postgres array like "{Option A, Option B}"
-            if v.startswith("{") and v.endswith("}"):
-                # Strip the brackets
-                cleaned = v[1:-1]
-                # Split by comma. This is a simplified split; 
-                # for robust parsing, JSON storage in DB is highly recommended.
-                # Here we strip extra quotes just in case.
-                items = [item.strip(' "') for item in cleaned.split(',')]
-                return items
-                
-            return [v] # Fallback: return the raw string as a single item list
-            
-        return v
 
-# --- PROGRESS SCHEMAS ---
+            if value.startswith("{") and value.endswith("}"):
+                cleaned = value[1:-1]
+                return [item.strip(' "') for item in cleaned.split(",") if item.strip()]
+
+            return [value]
+
+        return [str(value)]
+
+
 class ProgressUpdateRequest(BaseModel):
-    quality: int = Field(..., ge=0, le=5) 
+    quality: int = Field(..., ge=0, le=5)
+
 
 class ProgressUpdateResponse(BaseModel):
     status: str
@@ -107,6 +123,7 @@ class ProgressUpdateResponse(BaseModel):
     repetitions: int
     ease_factor: float
 
+
 class UserProgressBase(BaseModel):
     user_id: str
     lesson_id: int
@@ -115,19 +132,22 @@ class UserProgressBase(BaseModel):
     ease_factor: float
     next_review_date: date
 
+
 class UserProgressCreate(UserProgressBase):
     pass
+
 
 class UserProgress(UserProgressBase):
     id: int
 
     model_config = ConfigDict(from_attributes=True)
 
+
 class ModuleProgressSummary(BaseModel):
     module_id: int
     module_title: str
     total_lessons: int
-    lessons_started : int
-    mastery_score : float
+    lessons_started: int
+    mastery_score: float
 
     model_config = ConfigDict(from_attributes=True)

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+/**
+ * Admin console for curriculum and tenant operations.
+ * Page-level role checks gate UI visibility only; API authorization remains backend-enforced.
+ */
 import { useState, useEffect } from "react";
 import { createClient } from "@/lib/supabase";
 import { useRouter } from "next/navigation";
@@ -36,16 +40,13 @@ export default function AdminPage() {
   const [users, setUsers] = useState<UserRow[]>([]);
   const [loading, setLoading] = useState(true);
   
-  // Dynamic Modal State (Modules/Lessons)
   const [modal, setModal] = useState<ModalState>({ isOpen: false, mode: "new_module" });
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // Sanction/Ban Modal State
   const [banModal, setBanModal] = useState<BanModalState>({ isOpen: false, userId: "", userEmail: "" });
   const [banAction, setBanAction] = useState<"temp" | "perma" | "delete">("temp");
   const [isBanning, setIsBanning] = useState(false);
 
-  // Unified Form State
   const [form, setForm] = useState({
     title: "",
     description: "",
@@ -70,10 +71,13 @@ export default function AdminPage() {
         const meRes = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/users/me`, {
           headers: { Authorization: `Bearer ${session.access_token}` }
         });
-        const meData = await meRes.json();
+        if (!meRes.ok) {
+          throw new Error(`Unable to resolve admin profile: ${meRes.status}`);
+        }
+        const meData: Partial<UserRow> = await meRes.json();
         
         if (meData.role !== "admin") {
-          alert("SECURITY PROTOCOL: Unauthorized Access.");
+          alert("Unauthorized access.");
           router.push("/");
           return;
         }
@@ -83,8 +87,10 @@ export default function AdminPage() {
           fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/users`, { headers: { Authorization: `Bearer ${session.access_token}` } })
         ]);
 
-        setModules(await modRes.json());
-        setUsers(await usersRes.json());
+        const modulesPayload: unknown = await modRes.json();
+        const usersPayload: unknown = await usersRes.json();
+        setModules(Array.isArray(modulesPayload) ? (modulesPayload as Module[]) : []);
+        setUsers(Array.isArray(usersPayload) ? (usersPayload as UserRow[]) : []);
       } catch (err) {
         console.error("Admin fetch failed:", err);
       } finally {
@@ -95,20 +101,25 @@ export default function AdminPage() {
     fetchAdminData();
   }, [router, supabase]);
 
-  // --- MODAL CONTROLS ---
-
   const openNewModule = () => {
     setForm({ title: "", description: "", parentModuleId: "", contentText: "", contentMath: "", videoUrl: "" });
     setModal({ isOpen: true, mode: "new_module" });
   };
 
   const openEditModule = (mod: Module) => {
-    setForm({ ...form, title: mod.title, description: mod.description || "" });
+    setForm((previous) => ({ ...previous, title: mod.title, description: mod.description || "" }));
     setModal({ isOpen: true, mode: "edit_module", targetId: mod.id });
   };
 
   const openNewLesson = (moduleId?: number) => {
-    setForm({ ...form, title: "", contentText: "", contentMath: "", videoUrl: "", parentModuleId: moduleId ? moduleId.toString() : (modules[0]?.id.toString() || "") });
+    setForm((previous) => ({
+      ...previous,
+      title: "",
+      contentText: "",
+      contentMath: "",
+      videoUrl: "",
+      parentModuleId: moduleId ? moduleId.toString() : (modules[0]?.id.toString() || ""),
+    }));
     setModal({ isOpen: true, mode: "new_lesson" });
   };
 
@@ -118,24 +129,11 @@ export default function AdminPage() {
 
   const openBanModal = (userId: string, userEmail: string) => {
     setBanModal({ isOpen: true, userId, userEmail });
-    setBanAction("temp"); // Reset to default safely
+    setBanAction("temp");
   };
 
   const closeBanModal = () => {
     setBanModal({ isOpen: false, userId: "", userEmail: "" });
-  };
-
-  // --- ACTION HANDLERS ---
-
-  const handleExportLogs = () => {
-    const dataToExport = activeTab === "modules" ? modules : users;
-    const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(dataToExport, null, 2));
-    const downloadAnchorNode = document.createElement('a');
-    downloadAnchorNode.setAttribute("href", dataStr);
-    downloadAnchorNode.setAttribute("download", `spirelay_${activeTab}_export.json`);
-    document.body.appendChild(downloadAnchorNode);
-    downloadAnchorNode.click();
-    downloadAnchorNode.remove();
   };
 
   const handleModalSubmit = async () => {
@@ -146,7 +144,10 @@ export default function AdminPage() {
     
     setIsSubmitting(true);
     const { data: { session } } = await supabase.auth.getSession();
-    if (!session) return;
+    if (!session) {
+      setIsSubmitting(false);
+      return;
+    }
 
     try {
       if (modal.mode === "new_module") {
@@ -236,7 +237,6 @@ export default function AdminPage() {
     }
   };
 
-  // 🛡️ NEW: Wipe User Progress Handler
   const handleWipeProgress = async (userId: string, userEmail: string) => {
     if (!confirm(`CRITICAL WARNING: This will completely erase all SM-2 learning telemetry and mastery progress for ${userEmail}. Their account and role will remain intact. Proceed?`)) return;
 
@@ -244,7 +244,6 @@ export default function AdminPage() {
     if (!session) return;
 
     try {
-      // You will need to implement this endpoint on your FastAPI backend
       const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/admin/users/${userId}/progress`, {
         method: "DELETE",
         headers: { Authorization: `Bearer ${session.access_token}` }
@@ -266,7 +265,6 @@ export default function AdminPage() {
     
     try {
       if (banAction === "delete" && session) {
-         // await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/users/${banModal.userId}`, { method: "DELETE", ... })
          setUsers(users.filter(u => u.id !== banModal.userId));
       } else {
          alert(`User ${banModal.userEmail} has received a ${banAction} ban.`);

--- a/frontend/app/discover/page.tsx
+++ b/frontend/app/discover/page.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { useEffect, useState, useRef, useCallback } from "react";
+/**
+ * Discover page owns the vertical reel feed lifecycle.
+ * It synchronizes smart-feed data, active reel tracking, pull-to-refresh, and client-only video controls.
+ */
+import { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import { createClient } from "@/lib/supabase";
 import MathRenderer from "@/components/MathRenderer";
 import OptimizedVideoPlayer from "@/components/OptimizedVideoPlayer";
@@ -21,14 +25,12 @@ type Lesson = {
 
 const normalizeAspect = (aspect?: string | null): ReelAspect => {
   if (aspect === "portrait" || aspect === "square" || aspect === "landscape") return aspect;
-  // 🚀 TWEAK: Revert to landscape so desktop expands cinematically!
-  return "landscape"; 
+  return "landscape";
 };
 
 const normalizeFit = (fit?: string | null): ReelFit => {
   if (fit === "cover" || fit === "contain") return fit;
-  // Keeps mobile full-screen Reels style
-  return "cover"; 
+  return "cover";
 };
 
 export default function DiscoverPage() {
@@ -36,56 +38,75 @@ export default function DiscoverPage() {
   const [loading, setLoading] = useState(true);
   const [activeReelIndex, setActiveReelIndex] = useState(0);
   const [isGlobalMuted, setIsGlobalMuted] = useState(true);
-  
   const [isPulling, setIsPulling] = useState(false);
-  const touchStartY = useRef(0);
 
+  const touchStartY = useRef(0);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const supabase = createClient();
 
+  const isMountedRef = useRef(true);
+
   const fetchSmartFeed = useCallback(async () => {
-    setLoading(true);
-    const { data: { session } } = await supabase.auth.getSession();
+    if (isMountedRef.current) {
+      setLoading(true);
+    }
+
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
 
     if (!session) {
-      setLoading(false);
+      if (isMountedRef.current) {
+        setLessons([]);
+        setLoading(false);
+      }
       return;
     }
 
     try {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/feed/smart`, {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"}/api/feed/smart`, {
         headers: { Authorization: `Bearer ${session.access_token}` },
       });
 
-      const data = await response.json();
-      
-      if (Array.isArray(data)) {
-        setLessons(data);
-      } else {
+      if (!response.ok) {
+        throw new Error(`Smart feed request failed with status ${response.status}`);
+      }
+
+      const payload: unknown = await response.json();
+
+      if (isMountedRef.current) {
+        setLessons(Array.isArray(payload) ? (payload as Lesson[]) : []);
+        setActiveReelIndex(0);
+      }
+    } catch {
+      if (isMountedRef.current) {
         setLessons([]);
       }
-      setActiveReelIndex(0); 
-    } catch (err) {
-      console.error("Feed Sync Failed:", err);
-      setLessons([]); 
     } finally {
-      setLoading(false);
-      setIsPulling(false);
+      if (isMountedRef.current) {
+        setLoading(false);
+        setIsPulling(false);
+      }
     }
   }, [supabase]);
 
   useEffect(() => {
+    isMountedRef.current = true;
     void fetchSmartFeed();
+    return () => {
+      isMountedRef.current = false;
+    };
   }, [fetchSmartFeed]);
 
-  const safeLessons = Array.isArray(lessons) ? lessons : [];
+  const safeLessons = useMemo(() => (Array.isArray(lessons) ? lessons : []), [lessons]);
 
   useEffect(() => {
     if (safeLessons.length === 0) {
       setActiveReelIndex(0);
       return;
     }
+
     if (activeReelIndex > safeLessons.length - 1) {
       setActiveReelIndex(safeLessons.length - 1);
     }
@@ -120,11 +141,14 @@ export default function DiscoverPage() {
   }, [safeLessons]);
 
   const handleInject = async (lessonId: number) => {
-    const { data: { session } } = await supabase.auth.getSession();
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
     if (!session) return;
 
     try {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/progress/${lessonId}`, {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"}/api/progress/${lessonId}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -132,9 +156,12 @@ export default function DiscoverPage() {
         },
         body: JSON.stringify({ quality: 3 }),
       });
-      alert("Payload Injected: This lesson is now in your SM-2 queue!");
-    } catch (err) {
-      console.error("Injection failed:", err);
+
+      if (response.ok) {
+        alert("Payload Injected: This lesson is now in your SM-2 queue!");
+      }
+    } catch {
+      return;
     }
   };
 
@@ -147,7 +174,7 @@ export default function DiscoverPage() {
   const handleTouchMove = (e: React.TouchEvent) => {
     if (containerRef.current?.scrollTop === 0 && touchStartY.current > 0) {
       const currentY = e.touches[0].clientY;
-      if (currentY - touchStartY.current > 75) { 
+      if (currentY - touchStartY.current > 75) {
         setIsPulling(true);
       }
     }
@@ -164,9 +191,7 @@ export default function DiscoverPage() {
     return (
       <div className="flex h-[80vh] w-full flex-col items-center justify-center gap-4">
         <div className="h-12 w-12 animate-spin rounded-full border-4 border-sky-500/30 border-t-sky-400" />
-        <p className="font-mono text-sm tracking-widest text-sky-400">
-          SYNCING GLOBAL REELS...
-        </p>
+        <p className="font-mono text-sm tracking-widest text-sky-400">SYNCING GLOBAL REELS...</p>
       </div>
     );
   }
@@ -208,20 +233,18 @@ export default function DiscoverPage() {
               data-index={index}
               className="relative flex h-full w-full snap-start flex-col justify-start md:items-center md:justify-center overflow-hidden bg-black"
             >
-              {/* 1. DOMINANT VIDEO LAYER - Anchored to Top */}
               <div className="absolute inset-0 z-0 h-full w-full flex items-start md:items-center justify-center bg-black">
                 {lesson.video_url ? (
                   <OptimizedVideoPlayer
                     url={lesson.video_url}
                     aspect={aspect}
-                    fit={fit} // Will now default to "cover" to stretch across the screen
+                    fit={fit}
                     isActive={isActive}
                     shouldMount={shouldMount}
                     mode="feed"
                     isGlobalMuted={isGlobalMuted}
                     onToggleMute={() => setIsGlobalMuted((prev) => !prev)}
                     feedActionSlot={
-                      // 🚀 TWEAK 1: High-visibility Action Button
                       <button
                         onClick={() => handleInject(lesson.id)}
                         className="group flex flex-col items-center gap-1.5 md:gap-2 mb-4 md:mb-0 pointer-events-auto"
@@ -229,9 +252,7 @@ export default function DiscoverPage() {
                         <div className="flex h-30 w-12 md:h-12 md:w-12 items-center justify-center rounded-full border-2 border-sky-400/80 bg-gradient-to-br from-sky-500/20 to-blue-500/20 shadow-[0_4px_15px_rgba(0,0,0,0.6)] transition-all duration-300 active:scale-95 group-hover:scale-105 group-hover:border-sky-300 group-hover:bg-slate-800">
                           <span className="text-2xl md:text-xl drop-shadow-[0_0_10px_rgba(56,189,248,0.9)]">⚡</span>
                         </div>
-                        <span className="text-[10px] font-extrabold uppercase tracking-[0.15em] text-white ">
-                          Inject
-                        </span>
+                        <span className="text-[10px] font-extrabold uppercase tracking-[0.15em] text-white ">Inject</span>
                       </button>
                     }
                   />
@@ -243,21 +264,14 @@ export default function DiscoverPage() {
                 )}
               </div>
 
-              {/* 2. REELS-STYLE PROTECTION GRADIENTS */}
               <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-[65%] bg-gradient-to-t from-cyan-500/20 via-blue-500/20 to-transparent md:h-[45%] md:from-black/80 md:via-black/30" />
 
-              {/* 3. FOREGROUND INFORMATION OVERLAY */}
               <div className="relative z-20 flex h-full w-full flex-row items-end justify-between px-4 pb-4 md:px-8 md:pb-10 pointer-events-none">
-                
-                {/* BOTTOM-LEFT: Educational Content Zone */}
                 <div className="flex w-[82%] md:w-full max-w-xl flex-col gap-2.5 md:gap-5 animate-in fade-in slide-in-from-bottom-4 duration-500">
-                  
-                  {/* Title */}
                   <h2 className="pointer-events-auto text-2xl md:text-4xl font-black tracking-tight text-white drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)] leading-tight">
                     {lesson.title}
                   </h2>
 
-                  {/* Math Payload Card */}
                   {lesson.content_math && shouldMount && (
                     <div className="pointer-events-auto w-full max-w-[95%] md:max-w-lg overflow-hidden rounded-xl border border-white/10 bg-black/60 shadow-2xl backdrop-blur-xl">
                       <div className="border-b border-white/5 bg-white/5 px-3 py-1.5 md:px-4 md:py-2">
@@ -271,7 +285,6 @@ export default function DiscoverPage() {
                     </div>
                   )}
 
-                  {/* Explanation Description */}
                   {lesson.content_text && (
                     <p className="pointer-events-auto max-w-[95%] md:max-w-md rounded-xl bg-black/40 md:bg-gradient-to-r md:from-black/50 md:via-black/30 md:to-black/15 px-3 py-2 md:px-4 md:py-3 text-[13px] md:text-base leading-snug md:leading-6 text-slate-200 shadow-[0_2px_10px_rgba(0,0,0,0.5)] backdrop-blur-md border border-white/5 md:border-none line-clamp-3 md:line-clamp-none">
                       {lesson.content_text}
@@ -279,10 +292,7 @@ export default function DiscoverPage() {
                   )}
                 </div>
 
-                <div className="w-[18%] flex flex-col justify-end items-center pointer-events-none pb-2">
-                  {/* Space reserved for video player's right-aligned controls */}
-                </div>
-
+                <div className="w-[18%] flex flex-col justify-end items-center pointer-events-none pb-2" />
               </div>
             </section>
           );

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,17 +1,18 @@
-import ClientLayoutWrapper from '@/components/ClientLayoutWrapper';
-import './globals.css';
+import ClientLayoutWrapper from "@/components/ClientLayoutWrapper";
+import "./globals.css";
 
-// 1. PWA METADATA (Allowed because this is now a Server Component)
+/**
+ * Root server layout that declares PWA metadata and mounts the client shell.
+ */
 export const metadata = {
-  title: 'Spirelay',
-  description: 'Engineered Mastery',
-  manifest: '/manifest.json',
+  title: "Spirelay",
+  description: "Engineered Mastery",
+  manifest: "/manifest.json",
 };
 
-// 2. MOBILE VIEWPORT CONFIG
 export const viewport = {
-  themeColor: '#000000',
-  width: 'device-width',
+  themeColor: "#000000",
+  width: "device-width",
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
@@ -28,32 +29,19 @@ export default function RootLayout({
         <link rel="apple-touch-icon" href="/spirelay_logo_noBg.png" />
       </head>
       <body className="bg-black text-white min-h-screen flex flex-col">
-        
-        {/* 3. SERVICE WORKER REGISTRATION */}
         <script
           dangerouslySetInnerHTML={{
             __html: `
               if ('serviceWorker' in navigator) {
-                window.addEventListener('load', function() {
-                  navigator.serviceWorker.register('/sw.js').then(
-                    function(registration) {
-                      console.log('ServiceWorker registration successful');
-                    },
-                    function(err) {
-                      console.log('ServiceWorker registration failed: ', err);
-                    }
-                  );
-                });
+                window.addEventListener('load', function registerSpirelayServiceWorker() {
+                  navigator.serviceWorker.register('/sw.js').catch(function noop() {});
+                }, { once: true });
               }
             `,
           }}
         />
 
-        {/* 4. CLIENT NAVIGATION WRAPPER */}
-        <ClientLayoutWrapper>
-          {children}
-        </ClientLayoutWrapper>
-        
+        <ClientLayoutWrapper>{children}</ClientLayoutWrapper>
       </body>
     </html>
   );

--- a/frontend/src/components/AuthGuard.tsx
+++ b/frontend/src/components/AuthGuard.tsx
@@ -1,51 +1,58 @@
 "use client";
 
-import { useEffect, useState } from "react";
+/**
+ * Client-side route gate that prevents private page flashes while session state initializes.
+ * Final authorization is enforced server-side and via RLS; this only controls navigation flow.
+ */
+import { useEffect, useMemo, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { createClient } from "@/lib/supabase";
 
-// Routes that do NOT require authentication
 const PUBLIC_ROUTES = ["/login", "/signup", "/update-password"];
-// Routes meant for unauthenticated users only
 const GUEST_ONLY_ROUTES = ["/login", "/signup"];
 
 export default function AuthGuard({ children }: { children: React.ReactNode }) {
-  // Guard-level state controls whether private route content can render at all.
   const [isAuthorized, setIsAuthorized] = useState(false);
   const router = useRouter();
   const pathname = usePathname();
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
 
   useEffect(() => {
-    // Keeps route access synchronized with current session and current route classification.
+    let cancelled = false;
+
     const checkSecurityClearance = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (cancelled) return;
 
       const isPublicRoute = PUBLIC_ROUTES.includes(pathname);
-
       const isGuestOnly = GUEST_ONLY_ROUTES.includes(pathname);
 
       if (!session && !isPublicRoute) {
         setIsAuthorized(false);
-        // Intruder detected on a private route -> Bounce to login
         router.push("/login");
-      } else if (session && isGuestOnly) {
-        setIsAuthorized(false);
-        // Logged-in user trying to access login/signup -> Bounce to dashboard
-        router.push("/");
-      } else {
-        // Cleared!
-        setIsAuthorized(true);
+        return;
       }
+
+      if (session && isGuestOnly) {
+        setIsAuthorized(false);
+        router.push("/");
+        return;
+      }
+
+      setIsAuthorized(true);
     };
 
-    checkSecurityClearance();
+    void checkSecurityClearance();
 
-    // Syncs cross-tab auth transitions so route protection remains consistent everywhere.
-    const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
+    const { data: authListener } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (cancelled) return;
+
       const isPublicRoute = PUBLIC_ROUTES.includes(pathname);
       const isGuestOnly = GUEST_ONLY_ROUTES.includes(pathname);
-      
+
       if (!session && !isPublicRoute) {
         setIsAuthorized(false);
         router.push("/login");
@@ -58,27 +65,25 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
     });
 
     const handleVisibilityOrFocus = () => {
-      // Re-validates session when user returns to this tab/window.
       void checkSecurityClearance();
     };
 
-    // Defensive polling for token/session drift between auth callbacks.
     const recheckInterval = window.setInterval(() => {
       void checkSecurityClearance();
-    }, 1500);
+    }, 30000);
 
     window.addEventListener("focus", handleVisibilityOrFocus);
     document.addEventListener("visibilitychange", handleVisibilityOrFocus);
 
     return () => {
+      cancelled = true;
       window.clearInterval(recheckInterval);
       window.removeEventListener("focus", handleVisibilityOrFocus);
       document.removeEventListener("visibilitychange", handleVisibilityOrFocus);
       authListener.subscription.unsubscribe();
     };
-  }, [pathname, router, supabase.auth]);
+  }, [pathname, router, supabase]);
 
-  // Loading layer owns the full viewport to prevent private content flash before access resolves.
   if (!isAuthorized && !PUBLIC_ROUTES.includes(pathname)) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-[#0B0F19]">
@@ -92,6 +97,5 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
     );
   }
 
-  // Render the actual page if authorized
   return <>{children}</>;
 }

--- a/frontend/src/components/OptimizedVideoPlayer.tsx
+++ b/frontend/src/components/OptimizedVideoPlayer.tsx
@@ -1,4 +1,10 @@
 "use client";
+
+/**
+ * Unified media player for lesson focus mode and Discover feed mode.
+ * It normalizes YouTube URL variants into stable embed URLs and coordinates play/mute behavior
+ * so only the visible reel is active.
+ */
 import { useEffect, useState, useRef, useCallback, type ReactNode } from "react";
 
 type ReelAspect = "portrait" | "square" | "landscape";
@@ -16,37 +22,53 @@ interface OptimizedVideoPlayerProps {
   feedActionSlot?: ReactNode;
 }
 
-const getYouTubeEmbedId = (url: string): string => {
-  try {
-    const parsed = new URL(url);
-    if (parsed.hostname.includes("youtu.be")) return parsed.pathname.replace("/", "").trim();
-    if (parsed.searchParams.get("v")) return parsed.searchParams.get("v") || "";
-    const parts = parsed.pathname.split("/").filter(Boolean);
-    const embedIndex = parts.findIndex((part) => part === "embed");
-    if (embedIndex !== -1 && parts[embedIndex + 1]) return parts[embedIndex + 1];
-    return parts[parts.length - 1] || "";
-  } catch {
-    const parts = url.split("/");
-    return parts[parts.length - 1]?.split("?")[0] ?? "";
-  }
-};
-
-const buildYouTubeUrl = (url: string, mode: "feed" | "focus"): string => {
-  const videoId = getYouTubeEmbedId(url);
-
-  if (mode === "focus") {
-    return `https://www.youtube.com/embed/${videoId}?enablejsapi=1&rel=0&modestbranding=1`;
-  }
-
-  return `https://www.youtube.com/embed/${videoId}?enablejsapi=1&autoplay=0&mute=1&controls=0&loop=1&playlist=${videoId}&playsinline=1&modestbranding=1&rel=0`;
-};
-
-// 🚀 UPGRADED RAIL BUTTONS: Now they match the high-visibility Inject button style
 const railButtonClassName =
   "flex h-12 w-12 items-center justify-center rounded-full border-2 border-slate-600/80 bg-slate-900/90 backdrop-blur-xl shadow-[0_4px_15px_rgba(0,0,0,0.6)] transition-all duration-300 hover:scale-105 hover:bg-slate-800 hover:border-slate-500";
 
 const railLabelClassName =
   "text-[10px] font-extrabold uppercase tracking-[0.18em] text-white drop-shadow-[0_2px_4px_rgba(0,0,0,0.9)]";
+
+function isYouTubeUrl(url: string): boolean {
+  const normalized = url.toLowerCase();
+  return normalized.includes("youtube.com") || normalized.includes("youtube-nocookie.com") || normalized.includes("youtu.be");
+}
+
+function getYouTubeEmbedId(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+
+    if (host.includes("youtu.be")) {
+      return parsed.pathname.replace("/", "").trim();
+    }
+
+    const v = parsed.searchParams.get("v");
+    if (v) {
+      return v;
+    }
+
+    const pathParts = parsed.pathname.split("/").filter(Boolean);
+    const embedIndex = pathParts.findIndex((part) => part === "embed");
+    if (embedIndex >= 0 && pathParts[embedIndex + 1]) {
+      return pathParts[embedIndex + 1];
+    }
+
+    return pathParts[pathParts.length - 1] ?? "";
+  } catch {
+    const fallbackMatch = url.match(/(?:v=|youtu\.be\/|embed\/)([^?&/]+)/i);
+    return fallbackMatch?.[1] ?? "";
+  }
+}
+
+function buildYouTubeUrl(url: string, mode: "feed" | "focus"): string {
+  const videoId = getYouTubeEmbedId(url);
+
+  if (mode === "focus") {
+    return `https://www.youtube-nocookie.com/embed/${videoId}?enablejsapi=1&rel=0&modestbranding=1`;
+  }
+
+  return `https://www.youtube-nocookie.com/embed/${videoId}?enablejsapi=1&autoplay=0&mute=1&controls=0&loop=1&playlist=${videoId}&playsinline=1&modestbranding=1&rel=0`;
+}
 
 export default function OptimizedVideoPlayer({
   url,
@@ -59,7 +81,7 @@ export default function OptimizedVideoPlayer({
   onToggleMute,
   feedActionSlot,
 }: OptimizedVideoPlayerProps) {
-  const isYouTube = url.includes("youtube") || url.includes("youtu.be");
+  const isYouTube = isYouTubeUrl(url);
   const isFeed = mode === "feed";
 
   const [isPlaying, setIsPlaying] = useState(false);
@@ -74,7 +96,7 @@ export default function OptimizedVideoPlayer({
     if (iframeRef.current?.contentWindow) {
       iframeRef.current.contentWindow.postMessage(
         JSON.stringify({ event: "command", func, args }),
-        "https://www.youtube.com"
+        "https://www.youtube-nocookie.com"
       );
     }
   }, []);
@@ -95,7 +117,7 @@ export default function OptimizedVideoPlayer({
           sendYTCmd(currentlyMuted ? "mute" : "unMute");
         } else if (videoRef.current) {
           videoRef.current.muted = currentlyMuted;
-          void videoRef.current.play().catch(() => {});
+          void videoRef.current.play().catch(() => undefined);
         }
       }, 200);
     } else {
@@ -128,7 +150,7 @@ export default function OptimizedVideoPlayer({
       sendYTCmd(isPlaying ? "pauseVideo" : "playVideo");
     } else if (videoRef.current) {
       if (isPlaying) videoRef.current.pause();
-      else void videoRef.current.play().catch(() => {});
+      else void videoRef.current.play().catch(() => undefined);
     }
     setIsPlaying((prev) => !prev);
   };
@@ -137,9 +159,10 @@ export default function OptimizedVideoPlayer({
     e.stopPropagation();
     if (isFeed && onToggleMute) {
       onToggleMute();
-    } else {
-      setLocalMuted((prev) => !prev);
+      return;
     }
+
+    setLocalMuted((prev) => !prev);
   };
 
   if (!shouldMount) {
@@ -165,21 +188,18 @@ export default function OptimizedVideoPlayer({
     );
   }
 
-// 🚀 TWEAK: Enforce a max-height on desktop so it never overflows the monitor vertically
   const aspectClassMap: Record<ReelAspect, string> = {
     portrait: "h-full md:aspect-[9/16] md:max-h-[80vh]",
     square: "h-full md:aspect-square md:max-h-[80vh]",
     landscape: "h-full md:aspect-video md:max-h-[80vh]",
   };
 
-  // 🚀 TWEAK: Increased the landscape width to massive cinematic proportions on desktop (85vw)
   const frameWidthMap: Record<ReelAspect, string> = {
     portrait: "w-full md:max-w-md lg:max-w-lg",
     square: "w-full md:max-w-5xl",
     landscape: "w-full md:w-[85vw] max-w-7xl",
   };
 
-  // Ensure YouTube videos stretch far enough to cover vertical mobile screens without black bars
   const ytScaleMap: Record<ReelAspect, Record<ReelFit, string>> = {
     portrait: { cover: "w-[100%] h-[100%] md:w-[100%] md:h-[100%]", contain: "w-[100%] h-[100%]" },
     square: { cover: "w-[100%] h-[100%] md:w-[112%] md:h-[112%]", contain: "w-[100%] h-[100%]" },
@@ -204,11 +224,9 @@ export default function OptimizedVideoPlayer({
       </div>
 
       <div
-        // 🚀 TWEAK: Removed 'px-6' padding on mobile so the video touches the absolute edge of the phone.
         className={`absolute left-1/2 top-1/2 z-10 h-full md:h-auto w-full -translate-x-1/2 -translate-y-1/2 md:px-6 pointer-events-auto ${frameWidthMap[aspect]}`}
       >
         <div
-          // 🚀 TWEAK: Removed 'rounded-2xl border' on mobile. It now only looks like a card on desktop (md:).
           className={`relative w-full h-full rounded-xl border border-sky-500/20 md:h-auto overflow-hidden md:rounded-2xl md:border md:border-sky-500/20 bg-black shadow-[0_0_50px_rgba(56,189,248,0.15)] md:backdrop-blur-md ${aspectClassMap[aspect]}`}
         >
           {isYouTube ? (

--- a/frontend/src/hooks/useAdminRole.ts
+++ b/frontend/src/hooks/useAdminRole.ts
@@ -1,5 +1,9 @@
 "use client";
 
+/**
+ * Resolves whether the current authenticated user should see admin-only UI affordances.
+ * Authorization is enforced by backend policies; this hook only controls presentation.
+ */
 import { useEffect, useMemo, useState } from "react";
 import { createClient } from "@/lib/supabase";
 
@@ -9,27 +13,48 @@ export function useAdminRole() {
   const [roleLoading, setRoleLoading] = useState(true);
 
   useEffect(() => {
+    let cancelled = false;
+
     const resolveRole = async () => {
       setRoleLoading(true);
 
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
 
-      if (!user) {
-        setIsAdmin(false);
-        setRoleLoading(false);
-        return;
+        if (!user) {
+          if (!cancelled) {
+            setIsAdmin(false);
+            setRoleLoading(false);
+          }
+          return;
+        }
+
+        const { data, error } = await supabase
+          .from("users")
+          .select("role")
+          .eq("id", user.id)
+          .maybeSingle();
+
+        if (error) {
+          if (!cancelled) {
+            setIsAdmin(false);
+            setRoleLoading(false);
+          }
+          return;
+        }
+
+        if (!cancelled) {
+          setIsAdmin(data?.role?.toLowerCase() === "admin");
+          setRoleLoading(false);
+        }
+      } catch {
+        if (!cancelled) {
+          setIsAdmin(false);
+          setRoleLoading(false);
+        }
       }
-
-      const { data } = await supabase
-        .from("users")
-        .select("role")
-        .eq("id", user.id)
-        .maybeSingle();
-
-      setIsAdmin(data?.role?.toLowerCase() === "admin");
-      setRoleLoading(false);
     };
 
     void resolveRole();
@@ -40,7 +65,10 @@ export function useAdminRole() {
       void resolveRole();
     });
 
-    return () => subscription.unsubscribe();
+    return () => {
+      cancelled = true;
+      subscription.unsubscribe();
+    };
   }, [supabase]);
 
   return { isAdmin, roleLoading };


### PR DESCRIPTION
### Motivation
- Eliminate client-side races and memory leaks around Supabase auth so UI role checks remain presentation-only while backend RLS enforces authorization.
- Make the mobile-first Discover/Reels feed robust to late auth initialization, HTTP failures, and unmounted-state updates to prevent crashes and bad UX.
- Normalize YouTube/media parsing and backend lesson typing so varied legacy URLs/DB formats do not cause runtime errors in the player or API serializers.

### Description
- Made `useAdminRole` cancellation-safe and resilient, using `maybeSingle()` for Supabase lookups and guarding state writes when the hook is unmounted (`frontend/src/hooks/useAdminRole.ts`).
- Hardened client route protection in `AuthGuard` by stabilizing the Supabase client with `useMemo`, adding a `cancelled` flag, cleaning up listeners/timers, and reducing aggressive polling (`frontend/src/components/AuthGuard.tsx`).
- Improved Discover feed lifecycle with an `isMountedRef`, safer `fetch` handling with HTTP-status checks, `unknown` payload normalization, memoized `safeLessons`, and pull-to-refresh fixes to avoid setState on unmounted components (`frontend/app/discover/page.tsx`).
- Reworked `OptimizedVideoPlayer` YouTube parsing to support `youtube.com`, `youtu.be`, and `youtube-nocookie.com`, standardized embed URLs to privacy-friendly `youtube-nocookie.com`, and tightened play/mute promise handling and postMessage target origin (`frontend/src/components/OptimizedVideoPlayer.tsx`).
- Tightened backend lesson schema typing by replacing permissive `Any` with `QuizOptionsInput` union types and added a robust `@field_validator` that normalizes DB strings, Postgres array literals, JSON text, and dict/list shapes into `List[str]` for `LessonResponse.quiz_options` (`backend/schemas.py`).
- Cleaned `RootLayout` service-worker registration to a one-time safe registration without noisy console logging and preserved all visual/Tailwind classes (`frontend/app/layout.tsx`).
- Stabilized admin console bootstrapping by validating bootstrap responses, using functional `setForm` updates to avoid stale closures, and ensuring submit flows clear `isSubmitting` on missing session or error (`frontend/app/admin/page.tsx`).

### Testing
- Ran `python -m py_compile backend/schemas.py` and it completed successfully.
- Ran targeted linting: `cd frontend && npx eslint app/discover/page.tsx src/components/OptimizedVideoPlayer.tsx src/components/AuthGuard.tsx src/hooks/useAdminRole.ts app/layout.tsx app/admin/page.tsx` and the targeted files passed with no errors (only warnings addressed during edits).
- Ran full frontend lint `cd frontend && npm run lint` which failed due to pre-existing unrelated lint errors in `frontend/app/signup/page.tsx` (unescaped quotes), so that unrelated issue was not changed in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5aa95ea58832b9f176284fd0d1b72)